### PR TITLE
Rewrite type inference system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+Procyon.CompilerTools/build/
+Procyon.Core/build/
+Procyon.Decompiler/build/
+Procyon.Expressions/build/
+Procyon.Reflection/build/
+Procyon.CompilerTools/out/
+Procyon.Core/out/
+Procyon.Decompiler/out/
+Procyon.Expressions/out/
+Procyon.Reflection/out/
+out/
+.idea/
+.gradle/
+*.iml
+build/
+cache.txt

--- a/Procyon.CompilerTools/src/main/java/com/strobel/assembler/metadata/BuiltinTypes.java
+++ b/Procyon.CompilerTools/src/main/java/com/strobel/assembler/metadata/BuiltinTypes.java
@@ -16,7 +16,11 @@
 
 package com.strobel.assembler.metadata;
 
+import com.strobel.core.VerifyArgument;
 import com.strobel.util.ContractUtils;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * @author Mike Strobel
@@ -93,5 +97,45 @@ public final class BuiltinTypes {
             default:
                 throw ContractUtils.unreachable();
         }
+    }
+
+    private static final Map<Class<?>, TypeDefinition> CLASSES_TO_BUILTIN_TYPES;
+
+    static {
+        final HashMap<Class<?>, TypeDefinition> map = new HashMap<>();
+
+        map.put(Void.class, Void);
+        map.put(Boolean.class, Boolean);
+        map.put(Character.class, Character);
+        map.put(Byte.class, Byte);
+        map.put(Short.class, Short);
+        map.put(Integer.class, Integer);
+        map.put(Long.class, Long);
+        map.put(Float.class, Float);
+        map.put(Double.class, Double);
+
+        map.put(void.class, Void);
+        map.put(boolean.class, Boolean);
+        map.put(char.class, Character);
+        map.put(byte.class, Byte);
+        map.put(short.class, Short);
+        map.put(int.class, Integer);
+        map.put(long.class, Long);
+        map.put(float.class, Float);
+        map.put(double.class, Double);
+
+        CLASSES_TO_BUILTIN_TYPES = map;
+    }
+
+    public static TypeDefinition forClass(final Class<?> clazz) {
+        VerifyArgument.notNull(clazz, "clazz");
+
+        final TypeDefinition jvmType = CLASSES_TO_BUILTIN_TYPES.get(clazz);
+
+        if (jvmType != null) {
+            return jvmType;
+        }
+
+        return Object;
     }
 }

--- a/Procyon.CompilerTools/src/main/java/com/strobel/assembler/metadata/DefaultTypeVisitor.java
+++ b/Procyon.CompilerTools/src/main/java/com/strobel/assembler/metadata/DefaultTypeVisitor.java
@@ -16,6 +16,8 @@
 
 package com.strobel.assembler.metadata;
 
+import com.strobel.decompiler.ast.typeinference.AndType;
+
 public abstract class DefaultTypeVisitor<P, R> implements TypeMetadataVisitor<P, R> {
     public R visit(final TypeReference t) {
         return visit(t, null);
@@ -82,6 +84,11 @@ public abstract class DefaultTypeVisitor<P, R> implements TypeMetadataVisitor<P,
 
     @Override
     public R visitCapturedType(final CapturedType t, final P p) {
+        return visitType(t, p);
+    }
+
+    @Override
+    public R visitAndType(final AndType t, final P p) {
         return visitType(t, p);
     }
 }

--- a/Procyon.CompilerTools/src/main/java/com/strobel/assembler/metadata/GenericParameter.java
+++ b/Procyon.CompilerTools/src/main/java/com/strobel/assembler/metadata/GenericParameter.java
@@ -49,7 +49,7 @@ public final class GenericParameter extends TypeDefinition {
                                                  : GenericParameterType.Type;
     }
 
-    protected final void setExtendsBound(final TypeReference extendsBound) {
+    public final void setExtendsBound(final TypeReference extendsBound) {
         _extendsBound = extendsBound;
     }
 

--- a/Procyon.CompilerTools/src/main/java/com/strobel/assembler/metadata/TypeMetadataVisitor.java
+++ b/Procyon.CompilerTools/src/main/java/com/strobel/assembler/metadata/TypeMetadataVisitor.java
@@ -16,6 +16,8 @@
 
 package com.strobel.assembler.metadata;
 
+import com.strobel.decompiler.ast.typeinference.AndType;
+
 /**
  * @author Mike Strobel
  */
@@ -32,4 +34,5 @@ public interface TypeMetadataVisitor<P, R> {
     R visitNullType(final TypeReference t, final P p);
     R visitBottomType(final TypeReference t, final P p);
     R visitRawType(final RawType t, final P p);
+    R visitAndType(AndType t, P parameter);
 }

--- a/Procyon.CompilerTools/src/main/java/com/strobel/assembler/metadata/TypeSubstitutionVisitor.java
+++ b/Procyon.CompilerTools/src/main/java/com/strobel/assembler/metadata/TypeSubstitutionVisitor.java
@@ -17,10 +17,9 @@
 package com.strobel.assembler.metadata;
 
 import com.strobel.core.ArrayUtilities;
+import com.strobel.decompiler.ast.typeinference.AndType;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public final class TypeSubstitutionVisitor extends DefaultTypeVisitor<Map<TypeReference, TypeReference>, TypeReference>
     implements MethodMetadataVisitor<Map<TypeReference, TypeReference>, MethodReference>,
@@ -66,28 +65,30 @@ public final class TypeSubstitutionVisitor extends DefaultTypeVisitor<Map<TypeRe
             return t;
         }
 
-        if (current.isPrimitive()) {
-            switch (current.getSimpleType()) {
-                case Boolean:
-                    return CommonTypeReferences.Boolean;
-                case Byte:
-                    return CommonTypeReferences.Byte;
-                case Character:
-                    return CommonTypeReferences.Character;
-                case Short:
-                    return CommonTypeReferences.Short;
-                case Integer:
-                    return CommonTypeReferences.Integer;
-                case Long:
-                    return CommonTypeReferences.Long;
-                case Float:
-                    return CommonTypeReferences.Float;
-                case Double:
-                    return CommonTypeReferences.Double;
-                case Void:
-                    return CommonTypeReferences.Void;
-            }
-        }
+        // Disabled because we're using fake type variables for array element types
+        // Maybe use captured types instead?
+//        if (current.isPrimitive()) {
+//            switch (current.getSimpleType()) {
+//                case Boolean:
+//                    return CommonTypeReferences.Boolean;
+//                case Byte:
+//                    return CommonTypeReferences.Byte;
+//                case Character:
+//                    return CommonTypeReferences.Character;
+//                case Short:
+//                    return CommonTypeReferences.Short;
+//                case Integer:
+//                    return CommonTypeReferences.Integer;
+//                case Long:
+//                    return CommonTypeReferences.Long;
+//                case Float:
+//                    return CommonTypeReferences.Float;
+//                case Double:
+//                    return CommonTypeReferences.Double;
+//                case Void:
+//                    return CommonTypeReferences.Void;
+//            }
+//        }
 
         return current;
     }
@@ -158,6 +159,21 @@ public final class TypeSubstitutionVisitor extends DefaultTypeVisitor<Map<TypeRe
         }
 
         return t;
+    }
+
+
+    @Override
+    public TypeReference visitAndType(final AndType t, final Map<TypeReference, TypeReference> map) {
+        Set<TypeReference> newTypes = new LinkedHashSet<>();
+        for (TypeReference u : t.getTypes()) {
+            newTypes.add(visit(u, map));
+        }
+
+        if (newTypes.size() == 1) {
+            return newTypes.iterator().next();
+        }
+
+        return new AndType(newTypes.toArray(new TypeReference[0]));
     }
 
     @Override

--- a/Procyon.CompilerTools/src/main/java/com/strobel/decompiler/DecompilerContext.java
+++ b/Procyon.CompilerTools/src/main/java/com/strobel/decompiler/DecompilerContext.java
@@ -34,6 +34,7 @@ public final class DecompilerContext extends UserDataStoreBase {
     private BooleanBox _isCanceled;
     private TypeDefinition _currentType;
     private MethodDefinition _currentMethod;
+    private boolean _isInsideTypeBody;
 
     public DecompilerContext() {
     }
@@ -64,6 +65,14 @@ public final class DecompilerContext extends UserDataStoreBase {
 
     public void setCurrentType(final TypeDefinition currentType) {
         _currentType = currentType;
+    }
+
+    public boolean isInsideTypeBody() {
+        return _isInsideTypeBody;
+    }
+
+    public void setInsideTypeBody(boolean isInsideTypeBody) {
+        _isInsideTypeBody = isInsideTypeBody;
     }
 
     public MethodDefinition getCurrentMethod() {

--- a/Procyon.CompilerTools/src/main/java/com/strobel/decompiler/ast/AstOptimizer.java
+++ b/Procyon.CompilerTools/src/main/java/com/strobel/decompiler/ast/AstOptimizer.java
@@ -20,6 +20,7 @@ import com.strobel.assembler.metadata.*;
 import com.strobel.core.*;
 import com.strobel.decompiler.DecompilerContext;
 import com.strobel.decompiler.DecompilerSettings;
+import com.strobel.decompiler.ast.typeinference.TypeInferer;
 import com.strobel.functions.Function;
 import com.strobel.functions.Supplier;
 import com.strobel.functions.Suppliers;
@@ -106,7 +107,15 @@ public final class AstOptimizer {
             return;
         }
 
-        TypeAnalysis.run(context, method);
+        boolean fallback = false;
+        try {
+            new TypeInferer(context).solve(method);
+        } catch (Throwable t) {
+            // Fall back to old inference system
+            LOG.warning("Falling back to old inference system for " + context.getCurrentType().getFullName() + ":" + context.getCurrentMethod().getFullName());
+            fallback = true;
+            TypeAnalysis.run(context, method);
+        }
 
         boolean done = false;
 
@@ -217,7 +226,7 @@ public final class AstOptimizer {
                     return;
                 }
 
-                modified |= runOptimization(block, new InlineLambdasOptimization(context, method));
+                //modified |= runOptimization(block, new InlineLambdasOptimization(context, method));
 
                 if (!shouldPerformStep(abortBeforeStep, AstOptimizationStep.InlineVariables2)) {
                     done = true;
@@ -340,8 +349,10 @@ public final class AstOptimizer {
             return;
         }
 
-        TypeAnalysis.reset(context, method);
-        TypeAnalysis.run(context, method);
+        if (fallback) {
+            TypeAnalysis.reset(context, method);
+            TypeAnalysis.run(context, method);
+        }
 
         LOG.fine("Finished bytecode AST optimization.");
     }

--- a/Procyon.CompilerTools/src/main/java/com/strobel/decompiler/ast/AstOptimizer.java
+++ b/Procyon.CompilerTools/src/main/java/com/strobel/decompiler/ast/AstOptimizer.java
@@ -226,7 +226,7 @@ public final class AstOptimizer {
                     return;
                 }
 
-                //modified |= runOptimization(block, new InlineLambdasOptimization(context, method));
+                modified |= runOptimization(block, new InlineLambdasOptimization(context, method));
 
                 if (!shouldPerformStep(abortBeforeStep, AstOptimizationStep.InlineVariables2)) {
                     done = true;

--- a/Procyon.CompilerTools/src/main/java/com/strobel/decompiler/ast/typeinference/AndType.java
+++ b/Procyon.CompilerTools/src/main/java/com/strobel/decompiler/ast/typeinference/AndType.java
@@ -1,0 +1,46 @@
+package com.strobel.decompiler.ast.typeinference;
+
+import com.strobel.assembler.metadata.TypeMetadataVisitor;
+import com.strobel.assembler.metadata.TypeReference;
+import com.strobel.core.CollectionUtilities;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public class AndType extends TypeReference {
+    private final Set<TypeReference> types;
+
+    public AndType(TypeReference... types) {
+        Set<TypeReference> actualTypes = new LinkedHashSet<>();
+
+        for (TypeReference type : types) {
+            if (type instanceof AndType) {
+                actualTypes.addAll(((AndType) type).getTypes());
+            } else {
+                actualTypes.add(type);
+            }
+        }
+
+        this.types = actualTypes;
+    }
+
+    public Set<TypeReference> getTypes() {
+        return types;
+    }
+
+    @Override
+    public String getSimpleName() {
+        return CollectionUtilities.collectionToString(types, Object::toString, " & ");
+    }
+
+
+    @Override
+    public String getName() {
+        return getSimpleName();
+    }
+
+    @Override
+    public <R, P> R accept(TypeMetadataVisitor<P, R> visitor, P parameter) {
+        return visitor.visitAndType(this, parameter);
+    }
+}

--- a/Procyon.CompilerTools/src/main/java/com/strobel/decompiler/ast/typeinference/BoxedType.java
+++ b/Procyon.CompilerTools/src/main/java/com/strobel/decompiler/ast/typeinference/BoxedType.java
@@ -1,0 +1,31 @@
+package com.strobel.decompiler.ast.typeinference;
+
+import com.strobel.assembler.metadata.TypeMetadataVisitor;
+import com.strobel.assembler.metadata.TypeReference;
+
+public class BoxedType extends TypeReference {
+    private final TypeReference type;
+
+    public BoxedType(TypeReference type) {
+        this.type = type;
+    }
+
+    public TypeReference getType() {
+        return type;
+    }
+
+    @Override
+    public String getSimpleName() {
+        return type.getSimpleName();
+    }
+
+    @Override
+    public String getName() {
+        return getSimpleName();
+    }
+
+    @Override
+    public <R, P> R accept(TypeMetadataVisitor<P, R> visitor, P parameter) {
+        return visitor.visitType(type, parameter);
+    }
+}

--- a/Procyon.CompilerTools/src/main/java/com/strobel/decompiler/ast/typeinference/ConstraintSolver.java
+++ b/Procyon.CompilerTools/src/main/java/com/strobel/decompiler/ast/typeinference/ConstraintSolver.java
@@ -1,0 +1,267 @@
+package com.strobel.decompiler.ast.typeinference;
+
+import com.strobel.assembler.metadata.GenericParameter;
+import com.strobel.assembler.metadata.MetadataHelper;
+import com.strobel.assembler.metadata.TypeReference;
+
+import java.util.*;
+
+public class ConstraintSolver {
+    private Map<Object, EquivalenceSet> equivalences = new LinkedHashMap<>();
+    private Map<TypeReference, TypeReference> genericSubstitutions = new HashMap<>();
+    private Set<TypeReference> types = new HashSet<>();
+
+    public boolean addExtends(Object e1, Object e2) { // TODO: allow e1 and e2 to be constraint sets
+        e1 = processObject(e1);
+        e2 = processObject(e2);
+        if (e1.equals(e2)) return false;
+        print("type(" + e1 + ") <= type(" + e2 + ")");
+
+        EquivalenceSet s1 = getEquivalenceSet(e1);
+        EquivalenceSet s2 = getEquivalenceSet(e2);
+
+        return s1.supertypes.add(s2) | s2.subtypes.add(s1);
+    }
+
+    public boolean addEquality(Object e1, Object e2) { // TODO: allow e1 and e2 to be constraint sets
+        e1 = processObject(e1);
+        e2 = processObject(e2);
+        if (e1.equals(e2)) return false;
+        print("type(" + e1 + ") = type(" + e2 + ")");
+
+        // Handle generic parameter equality (substitute its use everywhere)
+        if (e1 instanceof TypeReference && e2 instanceof TypeReference) {
+            if (e1 instanceof GenericParameter && ((GenericParameter) e1).getOwner() == null) {
+                return addGenericSubstitution((GenericParameter) e1, (TypeReference) e2);
+            } else if (e2 instanceof GenericParameter && ((GenericParameter) e2).getOwner() == null) {
+                return addGenericSubstitution((GenericParameter) e2, (TypeReference) e1);
+            }
+        }
+
+        // Handle normal equality
+        EquivalenceSet s1 = equivalences.get(e1);
+        EquivalenceSet s2 = equivalences.get(e2);
+
+        if (s1 == null && s2 == null) {
+            EquivalenceSet info = new EquivalenceSet();
+            info.add(e1);
+            info.add(e2);
+            equivalences.put(e1, info);
+            equivalences.put(e2, info);
+        } else if (s1 == s2) {
+            return false;
+        } else if (s2 == null) {
+            s1.add(e2);
+            equivalences.put(e2, s1);
+        } else if (s1 == null) {
+            s2.add(e1);
+            equivalences.put(e1, s2);
+        } else {
+            mergeSets(s1, s2);
+        }
+
+        return true;
+    }
+
+    private EquivalenceSet mergeSets(EquivalenceSet into, EquivalenceSet from) {
+        for (Object o : from.getObjects()) {
+            into.add(o);
+            equivalences.put(o, into);
+        }
+
+        // Merge supertypes and subtypes
+        into.supertypes.addAll(from.supertypes);
+        into.supertypes.remove(from);
+        into.subtypes.addAll(from.subtypes);
+        into.subtypes.remove(from);
+
+        // Prevent sets extending themselves
+        into.supertypes.remove(into);
+        into.subtypes.remove(into);
+
+        for (EquivalenceSet set : getEquivalenceSets()) {
+            if (set.supertypes.remove(from)) {
+                set.supertypes.add(into);
+            }
+            if (set.subtypes.remove(from)) {
+                set.subtypes.add(into);
+            }
+        }
+
+        return into;
+    }
+
+    private boolean addGenericSubstitution(GenericParameter from, TypeReference to) {
+        if (from == to) {
+            throw new IllegalArgumentException("Can't replace generic parameter with itself");
+        }
+
+        TypeReference oldValue = genericSubstitutions.put(from, to);
+        if (oldValue == to) {
+            return false;
+        } else if (oldValue != null) {
+            throw new IllegalStateException("Tried to replace existing generic substitution");
+        }
+
+        Map<TypeReference, TypeReference> mappedTypes = new HashMap<>();
+        for (EquivalenceSet equivalenceSet : getEquivalenceSets()) { // TODO: Optimize by keeping a 'GenericParameter -> referring types' map updaed from processObject
+            Set<TypeReference> newTypes = new LinkedHashSet<>();
+            EquivalenceSet newSet = null;
+            boolean changed = false;
+            for (TypeReference type : equivalenceSet.types) {
+                TypeReference newType = mappedTypes.computeIfAbsent(type, t -> MetadataHelper.substituteGenericArguments(t, genericSubstitutions));
+                newTypes.add(newType);
+
+                if (!newType.equals(type)) {
+                    // Old type no longer exists
+                    equivalences.remove(type);
+                    changed = true;
+                }
+
+                // Substituting the type may cause the set to now be equal to another set
+                if (newSet == null || newSet == equivalenceSet) {
+                    newSet = equivalences.get(newType);
+                }
+            }
+            if (!changed) {
+                continue;
+            }
+            equivalenceSet.types = newTypes;
+
+            // Combine sets if generic substitution resulted in an equality
+            if (newSet != null && newSet != equivalenceSet) {
+                equivalenceSet = mergeSets(newSet, equivalenceSet);
+            }
+
+            // Update object to equivalence set map. This is done inside the for
+            // loop such that equivalences.get(newType) will correctly return this
+            // set if a generic substitution causes two sets to merge into a new set
+            // (ex. Map<String, T> and Map<T, String> merge when T -> String).
+            for (Object o : equivalenceSet.getObjects()) {
+                equivalences.put(o, equivalenceSet);
+            }
+        }
+
+        return true;
+    }
+
+    private EquivalenceSet getEquivalenceSet(Object e) {
+        return equivalences.computeIfAbsent(e, k -> {
+            EquivalenceSet set = new EquivalenceSet();
+            set.add(e);
+            return set;
+        });
+    }
+
+    public boolean add(Object e) {
+        if (equivalences.get(e) == null) {
+            getEquivalenceSet(e);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private Object processObject(Object o) {
+        if (o instanceof TypeReference) {
+            TypeReference type = (TypeReference) o;
+            type = MetadataHelper.substituteGenericArguments(type, genericSubstitutions);
+
+            if (types.add(type)) {
+                if (type.hasExtendsBound()) {
+                    addExtends(type, type.getExtendsBound());
+                }
+
+                if (type.hasSuperBound()) {
+                    addExtends(type.getSuperBound(), type);
+                }
+
+                // TODO: composite types
+            }
+
+            return type;
+        }
+
+        return o;
+    }
+
+    public Set<EquivalenceSet> solve() {
+        boolean needsPass = true;
+        while (needsPass) {
+            findAllConstraints();
+            solveAllUnique();
+            needsPass = solveAllSingleTypeVariables();
+        }
+
+        return getEquivalenceSets();
+    }
+
+    private Set<EquivalenceSet> getEquivalenceSets() {
+        return new LinkedHashSet<>(equivalences.values());
+    }
+
+    private boolean findAllConstraints() {
+        boolean changed = false;
+        boolean changedThisPass;
+        do {
+            print("***Finding constraints***");
+            changedThisPass = false;
+            for (EquivalenceSet type : getEquivalenceSets()) {
+                try {
+                    changedThisPass |= type.findConstraints(this);
+                } catch (Throwable t) {
+                    t.printStackTrace();
+                }
+            }
+            changed |= changedThisPass;
+        } while (changedThisPass);
+        return changed;
+    }
+
+    private boolean solveAllUnique() {
+        boolean changed = false;
+        boolean changedThisPass;
+        do {
+            print("***Solving unique***");
+            changedThisPass = false;
+            for (EquivalenceSet type : getEquivalenceSets()) {
+                try {
+                    changedThisPass |= type.solveUnique(this);
+                } catch (Throwable t) {
+                    t.printStackTrace();
+                }
+            }
+            changed |= changedThisPass;
+        } while (changedThisPass);
+        return changed;
+    }
+
+    private boolean solveAllSingleTypeVariables() {
+        boolean changed = false;
+        boolean changedThisPass;
+        do {
+            print("***Solving multiple***");
+            changedThisPass = false;
+            for (EquivalenceSet type : getEquivalenceSets()) {
+                try {
+                    changedThisPass |= type.solveMultiple(this);
+                } catch (Throwable t) {
+                    t.printStackTrace();
+                }
+            }
+            changed |= changedThisPass;
+
+            if (changedThisPass) {
+                findAllConstraints();
+                solveAllUnique();
+            }
+        } while (changedThisPass);
+        return changed;
+    }
+
+    private static void print(String s) {
+        if (InferenceSettings.PRINT) {
+            System.out.println(s);
+        }
+    }
+}

--- a/Procyon.CompilerTools/src/main/java/com/strobel/decompiler/ast/typeinference/EquivalenceSet.java
+++ b/Procyon.CompilerTools/src/main/java/com/strobel/decompiler/ast/typeinference/EquivalenceSet.java
@@ -1,0 +1,586 @@
+package com.strobel.decompiler.ast.typeinference;
+
+import com.strobel.assembler.metadata.*;
+import com.strobel.core.CollectionUtilities;
+import com.strobel.decompiler.ast.Expression;
+import com.strobel.decompiler.ast.Variable;
+
+import java.util.*;
+
+public class EquivalenceSet {
+    public Set<TypeReference> types = new LinkedHashSet<>();
+    public Set<Expression> expressions = new LinkedHashSet<>();
+    public Set<Variable> variables = new LinkedHashSet<>();
+
+    public Set<EquivalenceSet> supertypes = new LinkedHashSet<>();
+    public Set<EquivalenceSet> subtypes = new LinkedHashSet<>();
+
+    public TypeReference solution;
+
+    public void add(Object object) {
+        if (object instanceof TypeReference) {
+            types.add((TypeReference) object);
+        } else if (object instanceof Expression) {
+            expressions.add((Expression) object);
+        } else if (object instanceof Variable) {
+            variables.add((Variable) object);
+        } else {
+            throw new RuntimeException("Unknown type: " + object);
+        }
+    }
+
+    public Collection<Object> getObjects() {
+        List<Object> objects = new ArrayList<>(types.size() + expressions.size() + variables.size());
+        objects.addAll(types);
+        objects.addAll(expressions);
+        objects.addAll(variables);
+        return objects;
+    }
+
+    public boolean findConstraints(ConstraintSolver constraints) {
+        boolean changed = false;
+
+        // Create copies of these to avoid ConcurrentModificationException or change before next pass
+        Set<TypeReference> types = new LinkedHashSet<>(this.types);
+        Set<EquivalenceSet> supertypes = InferenceSettings.S_TRANSITIVITY ? getAllSupertypes() : new LinkedHashSet<>(this.supertypes);
+        Set<EquivalenceSet> subtypes = InferenceSettings.S_TRANSITIVITY ? getAllSubtypes() : new LinkedHashSet<>(this.subtypes);
+
+        // Check for equalities between subtypes and supertypes (T <= U <= T implies T == U)
+        if (InferenceSettings.S_CYCLE_EQUALITY_RULE) {
+            Set<TypeReference> commonTypes = getCommonSuperSubTypes(getAllSupertypes(), getAllSubtypes());
+            for (TypeReference type : commonTypes) {
+                changed |= addType(constraints, type);
+            }
+        }
+
+        // Solve equality constraints
+        GenericConstraintFinder equalityVisitor = new GenericConstraintFinder(constraints, GenericConstraintFinder.Mode.EQUALS);
+        for (TypeReference t : types) {
+            for (TypeReference u : types) {
+                if (t != u) {
+                    changed |= equalityVisitor.visit(t, u);
+                }
+            }
+        }
+
+        // Solve supertype and subtype constraints
+        GenericConstraintFinder supertypeVisitor = new GenericConstraintFinder(constraints, GenericConstraintFinder.Mode.EXTENDS);
+        GenericConstraintFinder subtypeVisitor = new GenericConstraintFinder(constraints, GenericConstraintFinder.Mode.SUPER);
+        for (TypeReference t : types) {
+            for (EquivalenceSet info : supertypes) {
+                for (TypeReference u : info.types) {
+                    if (t != u) {
+                        changed |= supertypeVisitor.visit(t, u);
+                    }
+                }
+            }
+        }
+
+        for (TypeReference t : types) {
+            for (EquivalenceSet info : subtypes) {
+                for (TypeReference u : info.types) {
+                    if (t != u) {
+                        changed |= subtypeVisitor.visit(t, u);
+                    }
+                }
+            }
+        }
+
+        // Type variable solving assumes everything extends Object, and it would
+        // be too hard to change that in a way that works with casts.
+        //
+        // If 'P <= T' where 'P' is a primitive type, then 'T <= P'. Transitivity
+        // is ok in this case since primitives can't be cast (using 'checkcast')
+        // and can't be generic arguments either.
+        if (InferenceSettings.S_PRIMITIVE_RULE) {
+            outer:
+            for (TypeReference subtype : getTypes(getAllSubtypes())) {
+                if (subtype.isPrimitive()) {
+                    for (TypeReference type : types) {
+                        if (type.isPrimitive()) {
+                            break outer;
+                        }
+                    }
+                    changed |= constraints.addExtends(getObjects().iterator().next(), subtype);
+                }
+            }
+        }
+
+        return changed;
+    }
+
+    private Set<TypeReference> getCommonSuperSubTypes(Set<EquivalenceSet> supertypes, Set<EquivalenceSet> subtypes) {
+        Set<TypeReference> commonTypes = new LinkedHashSet<>();
+        for (EquivalenceSet supertypeSet : supertypes) {
+            for (EquivalenceSet subtypeSet : subtypes) {
+                if (subtypeSet != this && supertypeSet != this) {
+                    for (TypeReference supertype : supertypeSet.types) {
+                        for (TypeReference subtype : subtypeSet.types) {
+                            if (MetadataHelper.isSameType(supertype, subtype)) {
+                                commonTypes.add(supertype);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return commonTypes;
+    }
+
+    private Set<EquivalenceSet> getAllSupertypes() {
+        LinkedHashSet<EquivalenceSet> results = new LinkedHashSet<>();
+        getAllSupertypes(this, results);
+        return results;
+    }
+
+    private void getAllSupertypes(EquivalenceSet current, Set<EquivalenceSet> results) {
+        for (EquivalenceSet supertype : current.supertypes) {
+            if (results.add(supertype)) {
+                getAllSupertypes(supertype, results);
+            }
+        }
+    }
+
+    private Set<EquivalenceSet> getAllSubtypes() {
+        LinkedHashSet<EquivalenceSet> results = new LinkedHashSet<>();
+        getAllSubtypes(this, results);
+        return results;
+    }
+
+    private void getAllSubtypes(EquivalenceSet current, Set<EquivalenceSet> results) {
+        for (EquivalenceSet subtype : current.subtypes) {
+            if (results.add(subtype)) {
+                getAllSubtypes(subtype, results);
+            }
+        }
+    }
+
+    public boolean solveUnique(ConstraintSolver constraints) {
+        boolean found = false;
+
+        // Look for solved type in types
+        if (solution == null) {
+            for (TypeReference type : types) {
+                if (!isUnsolved(type)) {
+                    if (found) {
+//                        throw new IllegalStateException("Set has two solutions: " + solution + ", " + type);
+                        return true;
+                        // TODO: hashCode and equals seems to be broken for UnresolvedGenericType, TypeDefinition, ParameterizedTypes
+                    }
+                    print("Found solution " + type + " in equivalence set " + this);
+                    setSolution(constraints, type);
+                    found = true;
+                }
+            }
+        }
+
+        return found;
+    }
+
+    private boolean isUnsolved(TypeReference type) {
+        if (!type.containsGenericParameters()) {
+            return false;
+        }
+
+        if (type instanceof GenericParameter) {
+            return ((GenericParameter) type).getOwner() == null;
+        }
+
+        if (type instanceof IGenericInstance) {
+            for (TypeReference typeArgument : ((IGenericInstance) type).getTypeArguments()) {
+                if (isUnsolved(typeArgument)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        if (type.isGenericDefinition()) {
+            for (GenericParameter typeParameter : type.getGenericParameters()) {
+                if (isUnsolved(typeParameter)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        if (type instanceof WildcardType) {
+            if (type.isUnbounded()) {
+                return false;
+            } else if (type.hasExtendsBound()) {
+                return isUnsolved(type.getExtendsBound());
+            } else if (type.hasSuperBound()) {
+                return isUnsolved(type.getSuperBound());
+            }
+        }
+
+        if (type instanceof ArrayType) {
+            return isUnsolved(type.getElementType());
+        }
+
+        return true;
+    }
+
+    private boolean addTypeVariablesInType(TypeReference type, ConstraintSolver constraints) {
+        Set<TypeReference> generics = new LinkedHashSet<>();
+        getTypeVariablesInType(type, generics);
+        boolean modified = false;
+        for (TypeReference generic : generics) {
+            modified |= constraints.add(generic);
+        }
+        return modified;
+    }
+
+    private void getTypeVariablesInType(TypeReference type, Set<? super GenericParameter> result) {
+        if (!type.containsGenericParameters()) {
+            return;
+        }
+
+        if (type instanceof GenericParameter) {
+            if (((GenericParameter) type).getOwner() == null) {
+                result.add((GenericParameter) type);
+            }
+        }
+
+        if (type instanceof IGenericInstance) {
+            for (TypeReference typeArgument : ((IGenericInstance) type).getTypeArguments()) {
+                getTypeVariablesInType(typeArgument, result);
+            }
+        }
+
+        if (type.isGenericDefinition()) {
+            for (GenericParameter typeParameter : type.getGenericParameters()) {
+                getTypeVariablesInType(typeParameter, result);
+            }
+        }
+
+        if (type instanceof WildcardType) {
+            if (type.hasExtendsBound()) {
+                getTypeVariablesInType(type.getExtendsBound(), result);
+            } else if (type.hasSuperBound()) {
+                getTypeVariablesInType(type.getSuperBound(), result);
+            }
+        }
+
+        if (type instanceof ArrayType) {
+            getTypeVariablesInType(type.getElementType(), result);
+        }
+    }
+
+    public boolean solveMultiple(ConstraintSolver constraints) {
+        // Skip if the set already has a solution
+        if (solution != null) {
+            return false;
+        }
+
+        if (solveUnique(constraints)) { // TODO: should not be necessary
+            return true;
+        }
+
+        boolean changed = false;
+
+        // Check that the only types in the set are type variable. For example, if we have:
+        //   - List<T> <= List<? extends Serializable>'
+        //   - T <= String
+        // we want to assign 'T = String' rather than 'T = ? extends Serializable'. Solving
+        // type variables only will always be enough to completely solve a system and will
+        // always give correct results as long as this step is not run before there are no
+        // additional constraints on type variables.
+        boolean canSolve = true;
+        for (TypeReference type : types) {
+            if (!(type instanceof GenericParameter)) {
+                if (isUnsolved(type)) {
+                    // Add unsolved generics to constraint solver if missing
+                    changed |= addTypeVariablesInType(type, constraints);
+                    canSolve = false;
+                }
+            }
+        }
+        if (!canSolve) {
+            return changed;
+        }
+
+        print("Solving single type variable: " + this);
+
+        // Solve the type variable. If A_TRANSITIVITY is false, transitivity is not
+        // used such that if 'T <= String <= U <= Object <= V', 'U' can be solved
+        // before solving 'V' and 'T'. However, this may cause problems with casts?
+        Set<EquivalenceSet> subtypes = this.subtypes;
+        Set<EquivalenceSet> supertypes = this.supertypes;
+
+        // Check if either the lower or upper bounds can be solved. Type variables in
+        // constraints can't be used, so don't attempt to find common supertype until
+        // all constraints on either side are known.
+        //
+        // Despite doing this, any system is guaranteed to be solvable if there are
+        // no cycles in the graph (which are removed by the T <= U <= T implies T = U
+        // rule).
+
+        if (InferenceSettings.A_LOWER_BOUND) {
+            boolean canSolveLowerBound = true;
+            for (EquivalenceSet subtypeSet : subtypes) {
+                if (subtypeSet.types.isEmpty()) {
+                    canSolveLowerBound = false;
+                } else {
+                    for (TypeReference subtype : subtypeSet.types) {
+                        if (isUnsolved(subtype)) {
+                            changed |= addTypeVariablesInType(subtype, constraints);
+                            canSolveLowerBound = false;
+                        }
+                    }
+                }
+            }
+
+            if (canSolveLowerBound) {
+                TypeReference leastUpperBound = null;
+                for (TypeReference subtype : getTypes(subtypes)) {
+                    if (!isUnsolved(subtype)) {
+                        leastUpperBound = leastUpperBound == null ? subtype : MetadataHelper.findCommonSuperType(leastUpperBound, subtype);
+                    }
+                }
+                if (leastUpperBound != null) {
+                    if (InferenceSettings.C_CASTS_ENABLED) {
+                        for (TypeReference supertype : getTypes(supertypes)) {
+                            if (!isUnsolved(supertype) && !MetadataHelper.isSubType(leastUpperBound, supertype)) {
+                                leastUpperBound = andType(leastUpperBound, supertype);
+                                print("  Cast required, lower bound does not extend upper bound: " + this);
+                                // TODO: just common supertype?
+                            }
+                        }
+                    }
+
+                    if (leastUpperBound instanceof WildcardType) {
+                        if (leastUpperBound.hasSuperBound()) {
+                            leastUpperBound = leastUpperBound.getSuperBound();
+                            // Technically, least upper bound would be Bottom (skip to finding greatest
+                            // lower bound of supertypes), but here it's not necessary
+                        } else if (leastUpperBound.hasExtendsBound()) {
+                            leastUpperBound = leastUpperBound.getExtendsBound();
+                        } else if (leastUpperBound.isUnbounded()) {
+                            leastUpperBound = CommonTypeReferences.Object;
+                        }
+                    }
+
+                    print("  Assigned least upper bound of subtypes: " + leastUpperBound);
+                    setSolution(constraints, leastUpperBound);
+                    return true;
+                }
+                // An empty set of lower bounds can't be solved, solve greatest upper bound instead
+            }
+        }
+
+        // Check if upper bound can be solved
+        boolean canSolveUpperBound = true;
+        for (EquivalenceSet supertypeSet : supertypes) {
+            if (supertypeSet.types.isEmpty()) {
+                canSolveUpperBound = false;
+            } else {
+                for (TypeReference supertype : supertypeSet.types) {
+                    if (isUnsolved(supertype)) {
+                        changed |= addTypeVariablesInType(supertype, constraints);
+                        canSolveUpperBound = false;
+                    }
+                }
+            }
+        }
+
+        if (canSolveUpperBound) {
+            TypeReference greatestLowerBound = null;
+            for (TypeReference superType : getTypes(supertypes)) {
+                if (greatestLowerBound == null || MetadataHelper.isSubType(superType, greatestLowerBound)) {
+                    greatestLowerBound = superType;
+                } else if (!MetadataHelper.isSubType(greatestLowerBound, superType)) {
+                    // TODO: Implement 'MetadataHelper.findCommonSubType'
+                    // Finding the least upper bound of the subtype constraints isn't always
+                    // possible since there may be no subtype constraints. In that case, the
+                    // supertype constraints must be respected by finding a common subtype for
+                    // them.
+                    TypeReference common = MetadataHelper.findCommonSubtype(greatestLowerBound, superType);
+
+                    if (common == null) {
+                        if (!InferenceSettings.C_CASTS_ENABLED) {
+                            throw new IllegalStateException("Can't extend both " + greatestLowerBound + " and " + superType);
+                        }
+
+                        print("Cast required, " + greatestLowerBound + " and " + superType + " have no common subtype. Equivalence set: " + this);
+                        common = andType(greatestLowerBound, superType);
+                        // Technically, we could just keep the lower bound, but that may mean a cast through object may be needed.
+                    }
+
+                    greatestLowerBound = common;
+                }
+            }
+            if (greatestLowerBound == null) {
+                greatestLowerBound = CommonTypeReferences.Object;
+            }
+            if (greatestLowerBound == TypeInferer.INT_OR_BOOLEAN) {
+                // We can't determine which was intended. Choosing int would be better because
+                // it's less confusing if it's wrong ('if (someCondition == 1)' is better than
+                // 'numberOfItems = true'), but that causes problems with some if/else transformation
+                // for some reason...
+                greatestLowerBound = BuiltinTypes.Boolean;
+            } else if (greatestLowerBound == TypeInferer.NUMERIC) {
+                // Type inference needs to be moved before any bytecode instruction set reduction
+                greatestLowerBound = BuiltinTypes.Integer;
+            }
+            if (greatestLowerBound instanceof WildcardType) {
+                if (greatestLowerBound.hasSuperBound()) {
+                    // Technically, greatest lower bound would be Object, but here it's not necessary
+                    greatestLowerBound = greatestLowerBound.getSuperBound();
+                } else if (greatestLowerBound.hasExtendsBound()) {
+                    greatestLowerBound = greatestLowerBound.getExtendsBound();
+                } else if (greatestLowerBound.isUnbounded()) {
+                    greatestLowerBound = CommonTypeReferences.Object;
+                }
+            }
+            print("  Assigned greatest lower bound of supertypes: " + greatestLowerBound);
+            setSolution(constraints, greatestLowerBound);
+            return true;
+        }
+
+        // Check if the upper bound can be partially solved. For example, 'T <= ArrayList<U>, List<V>'
+        // can be solved to 'T = ArrayList<E0>'. This is useful to make sure that something like
+        // 'T <= List<U>, List<String>' can be reduced to 'T = List<E0>' and then 'T = List<String>',
+        // rather than assigning 'U = Object'.
+        boolean canPartiallySolveUpperBound = true;
+        for (EquivalenceSet supertypeSet : supertypes) {
+            if (supertypeSet.types.isEmpty()) {
+                canPartiallySolveUpperBound = false;
+                break;
+            }
+
+            for (TypeReference supertype : supertypeSet.types) {
+                if (supertype instanceof GenericParameter) {
+                    canPartiallySolveUpperBound = false;
+                    break;
+                }
+            }
+        }
+
+        if (canPartiallySolveUpperBound) {
+            Set<TypeReference> newTypes = new LinkedHashSet<>();
+
+            for (TypeReference type : getTypes(supertypes)) {
+                if (type instanceof IGenericInstance) {
+                    type = (TypeReference) ((IGenericInstance) type).getGenericDefinition();
+                } else if (type instanceof ArrayType) {
+                    int order = 0;
+                    while (type instanceof ArrayType) {
+                        type = type.getElementType();
+                        order++;
+                    }
+
+                    if (type instanceof IGenericInstance) {
+                        type = (TypeReference) ((IGenericInstance) type).getGenericDefinition();
+                    } else if (type instanceof GenericParameter) {
+                        type = new GenericParameter("ElementType");
+                    } else {
+                        throw new IllegalStateException();
+                    }
+
+                    while (order-- > 0) {
+                        type = type.makeArrayType();
+                    }
+                }
+
+                newTypes.add(type);
+            }
+
+            TypeReference greatestLowerBound = null;
+            for (TypeReference superType : newTypes) {
+                if (greatestLowerBound == null || MetadataHelper.isSubType(superType, greatestLowerBound)) {
+                    greatestLowerBound = superType;
+                } else if (!MetadataHelper.isSubType(greatestLowerBound, superType)) {
+                    TypeReference common = MetadataHelper.findCommonSubtype(greatestLowerBound, superType);
+
+                    if (common == null) {
+                        throw new IllegalStateException("Can't extend both " + greatestLowerBound + " and " + superType); // TODO: casts
+                    }
+
+                    greatestLowerBound = common;
+                }
+            }
+
+            TypeReference renamedSolution = new TypeVariableRenamingVisitor().visit(greatestLowerBound);
+            print("  Partially solved to " + renamedSolution);
+            addType(constraints, renamedSolution);
+            return true;
+        }
+
+        print("  Neither upper or lower bound can be assigned");
+        return changed;
+    }
+
+    private TypeReference andType(TypeReference a, TypeReference b) {
+        if (InferenceSettings.C_USE_AND_TYPES) {
+            return new AndType(a, b);
+        } else if (InferenceSettings.C_BOX_CASTABLE_TYPES) {
+            return new BoxedType(MetadataHelper.findCommonSuperType(a, b));
+        } else {
+            return MetadataHelper.findCommonSuperType(a, b);
+        }
+    }
+
+    private Set<TypeReference> getTypes(Set<EquivalenceSet> typeSets) {
+        Set<TypeReference> supertpes = new LinkedHashSet<>();
+        for (EquivalenceSet supertypeSet : typeSets) {
+            supertpes.addAll(supertypeSet.types);
+        }
+        return supertpes;
+    }
+
+    private void setSolution(ConstraintSolver constraints, TypeReference solution) {
+        this.solution = solution;
+        addType(constraints, solution);
+    }
+
+    private boolean addType(ConstraintSolver constraints, TypeReference type) {
+        if (types.add(type)) {
+//            print("Added type " + solution + " to " + this);
+            for (Object o : getObjects()) {
+                if (o != type) {
+                    constraints.addEquality(o, type);
+                    return true;
+                }
+            }
+            // TODO: what if the set is empty...? it still has to be merged with the set of the type!
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        if (solution != null) {
+            Collection<Object> objects = new ArrayList<>(getObjects());
+            objects.remove(solution);
+            return solution.toString() + " for " + CollectionUtilities.collectionToString(objects, Object::toString);
+        }
+
+        return "[" +
+               CollectionUtilities.collectionToString(subtypes, EquivalenceSet::toShortString) +
+               " <= " +
+               toShortString() +
+               " <= " +
+               CollectionUtilities.collectionToString(supertypes, EquivalenceSet::toShortString) +
+               "]";
+    }
+
+    private String toShortString() {
+        if (solution != null) {
+            return solution.toString();
+        }
+
+        return "{" +
+               (expressions.isEmpty() ? "" : "e = " + CollectionUtilities.collectionToString(expressions, Expression::toString) + (variables.isEmpty() && types.isEmpty() ? "" : " | ")) +
+               (variables.isEmpty() ? "" : "v = " + CollectionUtilities.collectionToString(variables, Variable::toString) + (types.isEmpty() ? "" : " | ")) +
+               (types.isEmpty() ? "" : "t = " + CollectionUtilities.collectionToString(types, TypeReference::toString)) +
+               "}";
+    }
+
+    private static void print(String s) {
+        if (InferenceSettings.PRINT) {
+            System.out.println(s);
+        }
+    }
+}

--- a/Procyon.CompilerTools/src/main/java/com/strobel/decompiler/ast/typeinference/GenericConstraintFinder.java
+++ b/Procyon.CompilerTools/src/main/java/com/strobel/decompiler/ast/typeinference/GenericConstraintFinder.java
@@ -1,0 +1,265 @@
+package com.strobel.decompiler.ast.typeinference;
+
+import com.strobel.assembler.metadata.*;
+import com.strobel.util.ContractUtils;
+
+import java.util.List;
+
+public final class GenericConstraintFinder extends DefaultTypeVisitor<TypeReference, Boolean> {
+    public enum Mode { // relationship between t and u
+        EQUALS,
+        EXTENDS,
+        SUPER
+    }
+
+    private final ConstraintSolver constraints;
+    private final Mode mode;
+
+    public GenericConstraintFinder(ConstraintSolver constraints, Mode mode) {
+        this.constraints = constraints;
+        this.mode = mode;
+    }
+
+    @Override
+    public Boolean visit(TypeReference t, TypeReference u) {
+        return t.accept(this, u);
+    }
+
+    @Override
+    public Boolean visitArrayType(ArrayType t, TypeReference u) {
+        if (mode == Mode.EXTENDS && u.equals(CommonTypeReferences.Object)) { // Arrays extend object
+            return false;
+        }
+
+        if (u.isGenericParameter()) {
+            return false;
+        }
+
+        boolean changed = false;
+
+        if (mode == Mode.EQUALS) {
+            changed |= constraints.addEquality(t.getElementType(), u.getElementType());
+        } else if (mode == Mode.EXTENDS) {
+            changed |= constraints.addExtends(t.getElementType(), u.getElementType());
+        } else if (mode == Mode.SUPER) {
+            changed |= constraints.addExtends(u.getElementType(), t.getElementType());
+        }
+
+        return changed;
+    }
+
+    @Override
+    public Boolean visitGenericParameter(GenericParameter t, TypeReference u) {
+        if (mode == Mode.EQUALS && !t.equals(u)) {
+            return constraints.addEquality(t, u);
+        }
+        return false;
+    }
+
+    @Override
+    public Boolean visitWildcard(WildcardType t, TypeReference u) {
+        if (mode == Mode.EQUALS) {
+            if (!(u instanceof WildcardType)) {
+                //throw new IllegalStateException("Wildcard type " + t + " can't equal non-wildcard type " + u);
+                return false; // Casts break everything
+            }
+
+            if (t.hasExtendsBound() && u.hasExtendsBound()) {
+                return constraints.addEquality(t.getExtendsBound(), u.getExtendsBound());
+            } else if (t.hasSuperBound() && u.hasSuperBound()) {
+                return constraints.addEquality(t.getSuperBound(), u.getSuperBound());
+            } else {
+                throw new IllegalStateException("Wildcards " + t + " and " + u + " can't be equal");
+            }
+        } else if (mode == Mode.EXTENDS) {
+            if (t.hasSuperBound()) {
+                return constraints.addExtends(t.getSuperBound(), u);
+            }
+        } else if (mode == Mode.SUPER) {
+            if (t.hasExtendsBound()) {
+                return constraints.addExtends(u, t.getExtendsBound());
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public Boolean visitCompoundType(CompoundTypeReference t, TypeReference superType) {
+        return false; // TODO
+    }
+
+    @Override
+    public Boolean visitAndType(AndType t, TypeReference superType) {
+//        boolean changed = false;
+//        for (TypeReference u : t.getTypes()) {
+//            changed |= visit(u, superType);
+//        }
+//        return changed;
+        return false; // nothing to infer
+    }
+
+//    @Override
+//    public Boolean visitParameterizedType(TypeReference t, TypeReference u) {
+//        if (!(u instanceof IGenericInstance || u instanceof TypeDefinition)) {
+//            return false;
+////            throw new RuntimeException("Raw types not implemented, yet found relation between raw and parameterized type");
+//        }
+//
+//        if (!u.hasGenericParameters()) {
+//            return false;
+//        }
+//
+//        final List<? extends TypeReference> tArgs = ((IGenericInstance) t).getTypeArguments();
+//        final List<? extends TypeReference> uArgs = u instanceof IGenericInstance ? ((IGenericInstance) u).getTypeArguments() : u.getGenericParameters();
+//
+//        boolean changed = false;
+//        for (int i = 0; i < tArgs.size(); i++) {
+//            TypeReference tArg = tArgs.get(i);
+//            TypeReference uArg = uArgs.get(i);
+//            if (mode == Mode.EQUALS) {
+//                if (!tArg.equals(uArg)) {
+//                    changed |= constraints.addEquality(tArg, uArg);
+//                }
+//            } else if (mode == Mode.EXTENDS) {
+//                changed |= reduceCompatibilityConstraint(tArg, uArg);
+//            } else if (mode == Mode.SUPER) {
+//                changed |= reduceCompatibilityConstraint(uArg, tArg);
+//            }
+//        }
+//
+//        return changed;
+//    }
+
+    @Override
+    public Boolean visitClassType(TypeReference t, TypeReference u) {
+        if (u instanceof AndType) {
+            return false; // TODO: really nothing to do?
+        }
+
+        if (t instanceof GenericParameter || u instanceof GenericParameter ||
+            t.equals(BuiltinTypes.Object) || u.equals(BuiltinTypes.Object) ||
+            t instanceof WildcardType || u instanceof WildcardType ||
+            MetadataHelper.isSubType(t, u)) {
+            return false;
+        }
+
+        if (mode == Mode.EQUALS) {
+            boolean changed = false;
+            final List<? extends TypeReference> tArgs = t instanceof IGenericInstance ? ((IGenericInstance) t).getTypeArguments() : t.getGenericParameters();
+            final List<? extends TypeReference> uArgs = u instanceof IGenericInstance ? ((IGenericInstance) u).getTypeArguments() : u.getGenericParameters();
+            for (int i = 0; i < tArgs.size(); i++) {
+                TypeReference tArg = tArgs.get(i);
+                TypeReference uArg = uArgs.get(i);
+                changed |= constraints.addEquality(tArg, uArg);
+            }
+            return changed;
+        } else if (mode == Mode.EXTENDS) {
+            if (t.resolve().equals(u.resolve())) {
+                boolean changed = false;
+                final List<? extends TypeReference> tArgs = t instanceof IGenericInstance ? ((IGenericInstance) t).getTypeArguments() : t.getGenericParameters();
+                final List<? extends TypeReference> uArgs = u instanceof IGenericInstance ? ((IGenericInstance) u).getTypeArguments() : u.getGenericParameters();
+                for (int i = 0; i < tArgs.size(); i++) {
+                    TypeReference tArg = tArgs.get(i);
+                    TypeReference uArg = uArgs.get(i);
+                    changed |= reduceCompatibilityConstraint(tArg, uArg);
+                }
+                return changed;
+            } else {
+                boolean found = false;
+                boolean changed = false;
+
+                TypeReference tSuper = MetadataHelper.getSuperType(t);
+                if (tSuper != null && MetadataHelper.isSubType(tSuper.resolve(), u.resolve())) {
+                    changed |= visit(tSuper, u);
+                    found = true;
+                }
+
+                for (TypeReference tInterface : MetadataHelper.getInterfaces(t)) {
+                    if (MetadataHelper.isSubType(tInterface.resolve(), u.resolve())) {
+                        changed |= visit(tInterface, u);
+                        found = true;
+                    }
+                }
+
+                if (!found) {
+                    if (!InferenceSettings.C_CASTS_ENABLED) {
+                        throw new IllegalStateException("Illegal extends: " + t + " <= " + u);
+                    }
+
+                    print("Cast required: " + t + " <= " + u);
+                    return false;
+                }
+                return changed;
+            }
+        } else if (mode == Mode.SUPER) { // TODO: is this necessary? we'll eventually get to it anyway...
+            return new GenericConstraintFinder(constraints, Mode.EXTENDS).visit(u, t);
+        } else {
+            throw ContractUtils.unreachable();
+        }
+    }
+
+    private boolean reduceCompatibilityConstraint(TypeReference t, TypeReference u) {
+        // https://docs.oracle.com/javase/specs/jls/se8/html/jls-18.html#jls-18.2.2
+        if (t instanceof WildcardType && u instanceof WildcardType) {
+            if (t.hasExtendsBound() && u.hasExtendsBound()) {
+                return constraints.addExtends(t.getExtendsBound(), u.getExtendsBound());
+            } else if (t.hasExtendsBound() && u.isUnbounded()) { // Always true
+                return false;
+            } else if (t.hasSuperBound() && u.hasSuperBound()) {
+                return constraints.addExtends(u.getSuperBound(), t.getSuperBound());
+            } else if (t.hasSuperBound() && u.isUnbounded()) { // Always true
+                return false;
+            } else if (t.isUnbounded() && u.isUnbounded()) { // Always true
+                return false;
+            } else {
+                throw new IllegalStateException("Type " + t + " cannot be compatible with " + u);
+            }
+        } else if (u instanceof WildcardType) {
+            if (u.hasExtendsBound()) {
+                return constraints.addExtends(t, u.getExtendsBound());
+            } else if (u.hasSuperBound()) {
+                return constraints.addExtends(u.getSuperBound(), t);
+            } else { // Always true
+                return false;
+            }
+        } else {
+            return addSoftEquality(t, u);
+        }
+    }
+
+    private boolean addSoftEquality(TypeReference t, TypeReference u) {
+        if (!InferenceSettings.C_CASTS_ENABLED) {
+            return constraints.addEquality(t, u);
+        }
+
+        print("type(" + t + ") ~ type(" + u + ")");
+        return constraints.addExtends(t, u) | constraints.addExtends(u, t);
+    }
+
+    @Override
+    public Boolean visitPrimitiveType(PrimitiveType t, TypeReference superType) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitNullType(final TypeReference t, TypeReference superType) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitBottomType(final TypeReference t, TypeReference superType) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitRawType(final RawType t, TypeReference superType) {
+        return false;
+    }
+
+    private static void print(String s) {
+        if (InferenceSettings.PRINT) {
+            System.out.println(s);
+        }
+    }
+}

--- a/Procyon.CompilerTools/src/main/java/com/strobel/decompiler/ast/typeinference/InferenceSettings.java
+++ b/Procyon.CompilerTools/src/main/java/com/strobel/decompiler/ast/typeinference/InferenceSettings.java
@@ -1,0 +1,24 @@
+package com.strobel.decompiler.ast.typeinference;
+
+public class InferenceSettings {
+    public static final boolean PRINT = false;
+
+    // Cast options
+    public static final boolean C_CASTS_ENABLED = true;
+    public static final boolean C_USE_AND_TYPES = false;
+    public static final boolean C_BOX_CASTABLE_TYPES = false;
+
+    // Useful information - Disable when testing inference!
+    public static final boolean I_USE_CHECKCAST_TARGET = false;
+    public static final boolean I_USE_DEBUG_INFO = true;
+
+    // Constraint-finding options
+    public static final boolean S_TRANSITIVITY = true; // !C_CASTS_ENABLED
+    public static final boolean S_CYCLE_EQUALITY_RULE = true; // !C_CASTS_ENABLED
+    public static final boolean S_PRIMITIVE_RULE = true;
+
+    // Type variable assignment options
+    public static final boolean A_LOWER_BOUND = false;
+    public static final boolean A_PREFER_LOWER_BOUND = false;
+    public static final boolean A_TRANSITIVITY = false;
+}

--- a/Procyon.CompilerTools/src/main/java/com/strobel/decompiler/ast/typeinference/TypeInferer.java
+++ b/Procyon.CompilerTools/src/main/java/com/strobel/decompiler/ast/typeinference/TypeInferer.java
@@ -1,0 +1,541 @@
+package com.strobel.decompiler.ast.typeinference;
+
+import com.strobel.assembler.metadata.*;
+import com.strobel.core.StringComparison;
+import com.strobel.core.StringUtilities;
+import com.strobel.decompiler.DecompilerContext;
+import com.strobel.decompiler.ast.Label;
+import com.strobel.decompiler.ast.*;
+
+import java.util.*;
+
+public class TypeInferer {
+    public static final TypeDefinition INT_OR_BOOLEAN = new TypeDefinition() {
+        @Override
+        public String getSimpleName() {
+            return "int|boolean";
+        }
+
+        @Override
+        public String getName() {
+            return "int|boolean";
+        }
+
+        @Override
+        public boolean isPrimitive() {
+            return true;
+        }
+
+        @Override
+        public <R, P> R accept(TypeMetadataVisitor<P, R> visitor, P parameter) {
+            return visitor.visitClassType(this, parameter);
+        }
+    };
+
+    public static final TypeDefinition NUMERIC = new TypeDefinition() { // TODO: "or" types
+        @Override
+        public String getSimpleName() {
+            return "int|long|float|double";
+        }
+
+        @Override
+        public String getName() {
+            return "int|long|float|double";
+        }
+
+        @Override
+        public boolean isPrimitive() {
+            return true;
+        }
+
+        @Override
+        public <R, P> R accept(TypeMetadataVisitor<P, R> visitor, P parameter) {
+            return visitor.visitClassType(this, parameter);
+        }
+    };
+
+    private final DecompilerContext context;
+    private final ConstraintSolver constraints = new ConstraintSolver();
+    private Set<Expression> inferred = new HashSet<>();
+
+    public TypeInferer(DecompilerContext context) {
+        this.context = context;
+    }
+
+    public void solve(Block block) {
+        print("Inferring " + context.getCurrentMethod());
+        print("");
+        print(block);
+        print("");
+        long startTime = System.nanoTime();
+
+        findConstraintsFor(block);
+
+        Collection<EquivalenceSet> types = constraints.solve();
+
+        for (EquivalenceSet equivalenceSet : types) {
+            for (Expression expression : equivalenceSet.expressions) {
+                expression.setInferredType(expression.getInferredType() != null ? expression.getInferredType() : equivalenceSet.solution);
+                expression.setExpectedType(expression.getExpectedType() != null ? expression.getExpectedType() : equivalenceSet.solution);
+            }
+
+            for (Variable variable : equivalenceSet.variables) {
+                variable.setType(equivalenceSet.solution == null ? BuiltinTypes.Void : equivalenceSet.solution);
+            }
+        }
+        print((System.nanoTime() - startTime) / 1000000d + " ms");
+        print("");
+        print("");
+        print("");
+        print("");
+        print("");
+    }
+
+    public void findConstraintsFor(Block block) {
+        for (Node node : block.getBody()) {
+            if (node instanceof BasicBlock) {
+                findConstraintsFor((BasicBlock) node);
+            } else {
+                throw new RuntimeException("Unknown node: " + block);
+            }
+        }
+    }
+
+    public void findConstraintsFor(BasicBlock block) {
+        for (Node node : block.getBody()) {
+            if (node instanceof BasicBlock) {
+                findConstraintsFor((BasicBlock) node);
+            } else if (node instanceof Block) {
+                findConstraintsFor((Block) node);
+            } else if (node instanceof Expression) {
+                findConstraintsFor((Expression) node);
+            } else if (node instanceof TryCatchBlock) {
+                TryCatchBlock tryCatchBlock = (TryCatchBlock) node;
+                findConstraintsFor(tryCatchBlock.getTryBlock());
+                for (CatchBlock catchBlock : tryCatchBlock.getCatchBlocks()) {
+                    constraints.addEquality(catchBlock.getExceptionVariable(), catchBlock.getExceptionType());
+                    findConstraintsFor(catchBlock);
+                }
+                if (tryCatchBlock.getFinallyBlock() != null) {
+                    findConstraintsFor(tryCatchBlock.getFinallyBlock());
+                }
+            } else if (!(node instanceof Label)) {
+                throw new RuntimeException("Unknown node: " + block);
+            }
+        }
+    }
+
+    private void findConstraintsFor(Expression expression) {
+        if (!inferred.add(expression)) return;
+
+        if (expression.getOperand() instanceof Expression) {
+            findConstraintsFor((Expression) expression.getOperand());
+        }
+
+        for (Expression argument : expression.getArguments()) {
+            findConstraintsFor(argument);
+        }
+
+        AstCode code = expression.getCode();
+        switch (code) {
+            case LdC: {
+                Object constant = expression.getOperand();
+                if (constant instanceof String) {
+                    constraints.addEquality(expression, CommonTypeReferences.String);
+                } else if (constant instanceof TypeReference) {
+                    constraints.addEquality(expression, CommonTypeReferences.Class.resolve().makeGenericType((TypeReference) constant));
+                } else if (constant.getClass() == Integer.class) { // Integer can be an 'int' or 'boolean'
+                    if ((Integer) constant != 0 && (Integer) constant != 1) {
+                        constraints.addEquality(expression, BuiltinTypes.Integer);
+                    } else {
+                        constraints.addExtends(expression, INT_OR_BOOLEAN);
+                    }
+                } else {
+                    constraints.addEquality(expression, BuiltinTypes.forClass(constant.getClass()));
+                }
+                break;
+            }
+
+            case Store: {
+                constraints.addExtends(expression.getArguments().get(0), expression.getOperand());
+                break;
+            }
+
+            case Load: {
+                Variable variable = (Variable) expression.getOperand();
+                if (variable.isParameter()) {
+                    // Parameters have the correct generic types, generics don't need to be renamed
+                    ParameterDefinition parameter = variable.getOriginalParameter();
+                    TypeReference parameterType = parameter.getParameterType();
+                    constraints.addEquality(variable, parameterType);
+                }
+
+                constraints.addEquality(expression, variable);
+                break;
+            }
+
+            case CmpEq:
+            case CmpNe:
+            case CmpLt:
+            case CmpLe:
+            case CmpGt:
+            case CmpGe: {
+                constraints.addEquality(expression.getArguments().get(0), expression.getArguments().get(1));
+                constraints.addEquality(expression, BuiltinTypes.Boolean);
+                break;
+            }
+
+            case InvokeSpecial:
+            case InvokeStatic:
+            case InvokeInterface:
+            case InvokeVirtual: {
+                MethodReference methodRef = (MethodReference) expression.getOperand();
+                MethodDefinition method = methodRef.resolve();
+                Expression thisArgument = code != AstCode.InvokeStatic && code != AstCode.InvokeDynamic ? expression.getArguments().get(0) : null;
+
+                TypeVariableRenamingVisitor renamingVisitor = new TypeVariableRenamingVisitor();
+
+                if (thisArgument != null) {
+                    constraints.addExtends(thisArgument, renamingVisitor.visit(method.getDeclaringType()));
+                }
+
+                for (int i = 0; i < method.getParameters().size(); i++) {
+                    Expression argument = expression.getArguments().get(thisArgument != null ? i + 1 : i);
+                    TypeReference parameterType = method.getParameters().get(i).getParameterType();
+                    constraints.addExtends(argument, renamingVisitor.visit(parameterType));
+                }
+
+                constraints.addEquality(expression, renamingVisitor.visit(method.getReturnType())); // TODO: extends (for cast)
+                break;
+            }
+
+            case InvokeDynamic: {
+                DynamicCallSite callSite = (DynamicCallSite) expression.getOperand();
+                MethodReference bootstrapMethod = callSite.getBootstrapMethod();
+
+                if ("java/lang/invoke/LambdaMetafactory".equals(bootstrapMethod.getDeclaringType().getInternalName()) &&
+                    StringUtilities.equals("metafactory", bootstrapMethod.getName(), StringComparison.OrdinalIgnoreCase) &&
+                    callSite.getBootstrapArguments().size() == 3 &&
+                    callSite.getBootstrapArguments().get(1) instanceof MethodHandle) {
+
+                    MethodHandle targetHandle = (MethodHandle) callSite.getBootstrapArguments().get(1);
+                    MethodDefinition lambdaMethod = targetHandle.getMethod().resolve();
+
+                    TypeDefinition interfaceType = callSite.getMethodType().getReturnType().resolve();
+
+                    final List<MethodReference> methods = MetadataHelper.findMethods(interfaceType, MetadataFilters.matchName(callSite.getMethodName()));
+
+                    MethodDefinition interfaceMethod = null;
+                    for (MethodReference method : methods) {
+                        MethodDefinition resolvedMethod = method.resolve();
+                        if (resolvedMethod != null && resolvedMethod.isAbstract() && !resolvedMethod.isStatic() && !resolvedMethod.isDefault()) {
+                            interfaceMethod = resolvedMethod;
+                            break;
+                        }
+                    }
+
+                    TypeVariableRenamingVisitor renamingVisitor = new TypeVariableRenamingVisitor();
+
+                    // Get all the lambda argument parameters, including 'this'
+                    List<TypeReference> argumentTypes = new ArrayList<>();
+                    if (lambdaMethod.hasThis()) {
+                        argumentTypes.add(renamingVisitor.visit(lambdaMethod.getDeclaringType().resolve()));
+                    }
+                    for (ParameterDefinition parameterDefinition : lambdaMethod.getParameters()) {
+                        argumentTypes.add(renamingVisitor.visit(parameterDefinition.getParameterType().resolve()));
+                    }
+
+                    int interfaceParameterCount = interfaceMethod.getParameters().size();
+                    int invokedynamicArgumentCount = expression.getArguments().size();
+                    if (invokedynamicArgumentCount + interfaceParameterCount != argumentTypes.size()) {
+                        throw new IllegalStateException("Lambda parameter counts don't match");
+                    }
+
+                    // Match captured variables with invokedynamic arguments
+                    for (int i = 0; i < invokedynamicArgumentCount; i++) {
+                        constraints.addExtends(expression.getArguments().get(i), argumentTypes.get(i));
+                    }
+
+                    // Match remaining arguments with interface arguments
+                    for (int i = 0; i < interfaceParameterCount; i++) {
+                        TypeReference interfaceParam = renamingVisitor.visit(interfaceMethod.getParameters().get(i).getParameterType().resolve());
+                        constraints.addExtends(interfaceParam, argumentTypes.get(i + invokedynamicArgumentCount));
+                    }
+
+                    // Interface return type extends lambda return type. This is because type parameters are
+                    // dropped in lambda signatures ('T' -> 'Object', 'T extends String' -> 'String', etc.)
+                    // TODO: Infer the actual return type by inferring the lambda method in this TypeInferer
+                    if (targetHandle.getHandleType() == MethodHandleType.NewInvokeSpecial) { // TODO: extends (for cast)
+                        constraints.addEquality(renamingVisitor.visit(interfaceMethod.getReturnType()), renamingVisitor.visit(lambdaMethod.getDeclaringType().resolve()));
+                    } else {
+                        constraints.addEquality(renamingVisitor.visit(interfaceMethod.getReturnType()), renamingVisitor.visit(lambdaMethod.getReturnType()));
+                    }
+
+                    // Type of expresion is interfaceType
+                    constraints.addEquality(expression, renamingVisitor.visit(interfaceType));
+                }
+                break;
+            }
+
+            case IfTrue: {
+                constraints.addEquality(expression.getArguments().get(0), BuiltinTypes.Boolean);
+                break;
+            }
+
+            case LogicalNot:
+            case LogicalAnd:
+            case LogicalOr: {
+                constraints.addEquality(expression.getOperand(), BuiltinTypes.Boolean);
+                for (Expression arg : expression.getArguments()) {
+                    constraints.addEquality(arg, BuiltinTypes.Boolean);
+                }
+                break;
+            }
+
+            case Goto: {
+                break;
+            }
+
+            case Return: { // TODO: resolve?
+                if (expression.getArguments().size() > 0) {
+                    constraints.addExtends(expression.getArguments().get(0), context.getCurrentMethod().getReturnType());
+                }
+                break;
+            }
+
+            case __New: {
+                TypeDefinition resolved = ((TypeReference) expression.getOperand()).resolve();
+                constraints.addEquality(expression, new TypeVariableRenamingVisitor().visit(resolved)); // TODO: extends (for cast)
+                break;
+            }
+
+            case GetField: {
+                TypeVariableRenamingVisitor renamingVisitor = new TypeVariableRenamingVisitor();
+                TypeReference fieldType = renamingVisitor.visit(((FieldReference) expression.getOperand()).resolve().getFieldType());
+                TypeReference fieldOwner = renamingVisitor.visit(((FieldReference) expression.getOperand()).resolve().getDeclaringType());
+                constraints.addExtends(expression.getArguments().get(0), fieldOwner); // TODO: Use access level?
+                constraints.addEquality(expression, fieldType); // TODO: extends (for cast)
+                break;
+            }
+
+            case PutField: {
+                TypeVariableRenamingVisitor renamingVisitor = new TypeVariableRenamingVisitor();
+                TypeReference fieldType = renamingVisitor.visit(((FieldReference) expression.getOperand()).resolve().getFieldType());
+                TypeReference fieldOwner = renamingVisitor.visit(((FieldReference) expression.getOperand()).resolve().getDeclaringType());
+                constraints.addExtends(expression.getArguments().get(0), fieldOwner); // TODO: Use access level?
+                constraints.addExtends(expression.getArguments().get(1), fieldType);
+                break;
+            }
+
+            case GetStatic: {
+                TypeVariableRenamingVisitor renamingVisitor = new TypeVariableRenamingVisitor();
+                TypeReference fieldType = renamingVisitor.visit(((FieldReference) expression.getOperand()).resolve().getFieldType());
+                constraints.addEquality(expression, fieldType);
+                break;
+            }
+
+            case PutStatic: {
+                TypeVariableRenamingVisitor renamingVisitor = new TypeVariableRenamingVisitor();
+                TypeReference fieldType = renamingVisitor.visit(((FieldReference) expression.getOperand()).resolve().getFieldType()); // TODO: resolve necessary for equality but what about generics
+                constraints.addExtends(expression.getArguments().get(0), fieldType);
+                break;
+            }
+
+            case Sub:
+            case Add:
+            case Or:
+            case And:
+            case Mul:
+            case Div:
+            case Shl:
+            case Shr:
+            case UShr:
+            case Rem:
+            case Xor: {
+                constraints.addEquality(expression.getArguments().get(0), expression.getArguments().get(1));
+                constraints.addEquality(expression, expression.getArguments().get(1));
+                constraints.addExtends(expression, NUMERIC); // Equality makes sure args extend numeric too
+                break;
+            }
+
+            case AConstNull: {
+                // TODO: use Null type?
+                // that would require extra code to prevent (Null <= T) assigining Null to T
+                constraints.addExtends(expression, BuiltinTypes.Object);
+                break;
+            }
+
+            case CheckCast: {
+                if (InferenceSettings.I_USE_CHECKCAST_TARGET) {
+                    TypeReference targetType = (TypeReference) expression.getOperand();
+                    constraints.addExtends(expression, new TypeVariableRenamingVisitor().visit(targetType.resolve()));
+                }
+                // TODO: ignoring casts produces better results with generics, but may cause incorrect results.
+                constraints.addEquality(expression, expression.getArguments().get(0));
+                break;
+            }
+
+            case I2B:
+            case I2S:
+            case I2C:
+            case I2L:
+            case I2D:
+            case I2F:
+            case D2F:
+            case D2I:
+            case D2L:
+            case L2F:
+            case L2I:
+            case L2D:
+            case F2D:
+            case F2I:
+            case F2L: {
+                if (code == AstCode.I2B || code == AstCode.I2S || code == AstCode.I2C ||
+                    code == AstCode.I2L || code == AstCode.I2D || code == AstCode.I2F) {
+                    constraints.addEquality(expression.getArguments().get(0), BuiltinTypes.Integer);
+                } else if (code == AstCode.D2F || code == AstCode.D2I || code == AstCode.D2L) {
+                    constraints.addEquality(expression.getArguments().get(0), BuiltinTypes.Double);
+                } else if (code == AstCode.L2D || code == AstCode.L2F || code == AstCode.L2I) {
+                    constraints.addEquality(expression.getArguments().get(0), BuiltinTypes.Long);
+                } else if (code == AstCode.F2D || code == AstCode.F2I || code == AstCode.F2L) {
+                    constraints.addEquality(expression.getArguments().get(0), BuiltinTypes.Float);
+                } else {
+                    throw new RuntimeException("Forgot to add code " + code);
+                }
+
+                if (code == AstCode.D2I || code == AstCode.F2I || code == AstCode.L2I) {
+                    constraints.addEquality(expression, BuiltinTypes.Integer);
+                } else if (code == AstCode.I2D || code == AstCode.F2D || code == AstCode.L2D) {
+                    constraints.addEquality(expression, BuiltinTypes.Double);
+                } else if (code == AstCode.I2F || code == AstCode.D2F || code == AstCode.L2F) {
+                    constraints.addEquality(expression, BuiltinTypes.Float);
+                } else if (code == AstCode.I2L || code == AstCode.D2L || code == AstCode.F2L) {
+                    constraints.addEquality(expression, BuiltinTypes.Long);
+                } else if (code == AstCode.I2B) {
+                    constraints.addEquality(expression, BuiltinTypes.Byte);
+                } else if (code == AstCode.I2S) {
+                    constraints.addEquality(expression, BuiltinTypes.Short);
+                } else if (code == AstCode.I2C) {
+                    constraints.addEquality(expression, BuiltinTypes.Character);
+                } else {
+                    throw new RuntimeException("Forgot to add code " + code);
+                }
+
+                break;
+            }
+
+            case NewArray: {
+                constraints.addEquality(expression.getArguments().get(0), BuiltinTypes.Integer);
+                TypeReference elementType = new TypeVariableRenamingVisitor().visit(((TypeReference) expression.getOperand()).resolve());
+                constraints.addEquality(expression, ArrayType.create(elementType));
+                break;
+            }
+
+            case __LCmp: {
+                constraints.addEquality(expression.getArguments().get(0), BuiltinTypes.Long);
+                constraints.addEquality(expression.getArguments().get(1), BuiltinTypes.Long);
+                constraints.addEquality(expression, BuiltinTypes.Boolean);
+                break;
+            }
+
+            case __DCmpG:
+            case __DCmpL: {
+                constraints.addEquality(expression.getArguments().get(0), BuiltinTypes.Double);
+                constraints.addEquality(expression.getArguments().get(1), BuiltinTypes.Double);
+                constraints.addEquality(expression, BuiltinTypes.Boolean);
+                break;
+            }
+
+            case __FCmpG:
+            case __FCmpL: {
+                constraints.addEquality(expression.getArguments().get(0), BuiltinTypes.Float);
+                constraints.addEquality(expression.getArguments().get(1), BuiltinTypes.Float);
+                constraints.addEquality(expression, BuiltinTypes.Boolean);
+                break;
+            }
+
+            case InstanceOf: {
+                constraints.addEquality(expression, BuiltinTypes.Boolean);
+                break;
+            }
+
+            case Inc: {
+                constraints.addEquality(expression.getOperand(), expression.getArguments().get(0));
+                constraints.addExtends(expression.getOperand(), NUMERIC);
+                break;
+            }
+
+            case AThrow: {
+                constraints.addExtends(expression.getArguments().get(0), CommonTypeReferences.Throwable);
+                break;
+            }
+
+            case LoadElement: {
+                TypeReference elementType = new TypeVariableRenamingVisitor().visit(new GenericParameter("ElementType"));
+                constraints.addEquality(expression.getArguments().get(0), ArrayType.create(elementType));
+                constraints.addEquality(expression.getArguments().get(1), BuiltinTypes.Integer);
+                constraints.addEquality(expression, elementType);
+                break;
+            }
+
+            case StoreElement: {
+                TypeReference elementType = new TypeVariableRenamingVisitor().visit(new GenericParameter("ElementType"));
+                constraints.addEquality(expression.getArguments().get(0), ArrayType.create(elementType));
+                constraints.addEquality(expression.getArguments().get(1), BuiltinTypes.Integer);
+                constraints.addExtends(expression.getArguments().get(1), elementType);
+                break;
+            }
+
+            case ArrayLength: {
+                TypeReference elementType = new TypeVariableRenamingVisitor().visit(new GenericParameter("ElementType"));
+                constraints.addExtends(expression.getArguments().get(0), ArrayType.create(elementType));
+                constraints.addEquality(expression, BuiltinTypes.Integer);
+                break;
+            }
+
+            case PreIncrement: {
+                constraints.addEquality(expression, expression.getArguments().get(0));
+                break;
+            }
+
+            case Switch: {
+                constraints.addEquality(expression.getArguments().get(0), BuiltinTypes.Integer);
+                break;
+            }
+
+            case MonitorEnter:
+            case MonitorExit: {
+                constraints.addExtends(expression.getArguments(), BuiltinTypes.Object);
+                break;
+            }
+
+            case Neg: {
+                constraints.addEquality(expression, expression.getArguments().get(0));
+                break;
+            }
+
+            case Leave:
+            case EndFinally: {
+                break;
+            }
+
+            case MultiANewArray: { // TODO: resolve and box
+                constraints.addEquality(expression, expression.getOperand());
+                for (Expression e : expression.getArguments()) {
+                    constraints.addEquality(e, BuiltinTypes.Integer);
+                }
+                break;
+            }
+
+            default: {
+                throw new RuntimeException("Unknown expression: " + expression);
+            }
+        }
+    }
+
+    private static void print(Object o) {
+        if (InferenceSettings.PRINT) {
+            System.out.println(o);
+        }
+    }
+}

--- a/Procyon.CompilerTools/src/main/java/com/strobel/decompiler/ast/typeinference/TypeVariableRenamingVisitor.java
+++ b/Procyon.CompilerTools/src/main/java/com/strobel/decompiler/ast/typeinference/TypeVariableRenamingVisitor.java
@@ -1,0 +1,102 @@
+package com.strobel.decompiler.ast.typeinference;
+
+import com.strobel.assembler.metadata.*;
+import com.strobel.core.CollectionUtilities;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class TypeVariableRenamingVisitor extends DefaultTypeVisitor<Void, TypeReference> { // TODO: use captured types instead of renaming?
+    public Map<GenericParameter, GenericParameter> renamedParameters = new HashMap<>();
+    public static Map<String, Integer> counters = new HashMap<>();
+
+    @Override
+    public TypeReference visit(final TypeReference t, Void v) {
+        return t.accept(this, null);
+    }
+
+    @Override
+    public TypeReference visitArrayType(final ArrayType t, Void v) {
+        return visit(t.getElementType(), null).makeArrayType();
+    }
+
+    public int getNextCounter(String name) {
+        if (Character.isDigit(name.charAt(name.length() - 1))) {
+            name = name + "_";
+        }
+
+        int result = counters.getOrDefault(name, 0);
+        counters.put(name, result + 1);
+        return result;
+    }
+
+    @Override
+    public TypeReference visitGenericParameter(GenericParameter t, Void v) {
+        GenericParameter renamed = renamedParameters.get(t);
+
+        if (renamed == null) {
+            renamed = new GenericParameter(t.getName() + String.valueOf(getNextCounter(t.getName())));
+
+            // Add before visiting extends bound to avoid infinite recursion (for example, with 'T extends Comparable<T>')
+            renamedParameters.put(t, renamed);
+
+            if (t.hasExtendsBound()) {
+                renamed.setExtendsBound(visit(t.getExtendsBound()));
+            }
+        }
+
+        return renamed;
+    }
+
+    @Override
+    public TypeReference visitWildcard(WildcardType t, Void v) {
+        if (t.hasExtendsBound()) {
+            return WildcardType.makeExtends(visit(t.getExtendsBound(), null));
+        } else if (t.hasSuperBound()) {
+            return WildcardType.makeSuper(visit(t.getSuperBound(), null));
+        } else {
+            return t;
+        }
+    }
+
+    @Override
+    public TypeReference visitCompoundType(final CompoundTypeReference t, Void v) {
+        return new CompoundTypeReference(t.getBaseType() == null ? visit(t.getBaseType(), null) : null,
+                t.getInterfaces() != null ? CollectionUtilities.map(t.getInterfaces(), i -> visit(i, null)) : null);
+    }
+
+    @Override
+    public TypeReference visitParameterizedType(final TypeReference t, Void v) {
+        return t.makeGenericType(CollectionUtilities.map(((IGenericInstance) t).getTypeArguments(), arg -> visit(arg, null)));
+    }
+
+    @Override
+    public TypeReference visitPrimitiveType(final PrimitiveType t, Void v) {
+        return t;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public TypeReference visitClassType(final TypeReference t, Void v) {
+        final TypeReference resolvedType = t.isGenericType() ? t : t.resolve();
+        final List<TypeReference> typeArguments = (List<TypeReference>) (Object) resolvedType.getGenericParameters();
+
+        return typeArguments.isEmpty() ? t : t.makeGenericType(CollectionUtilities.map(typeArguments, arg -> visit(arg, null)));
+    }
+
+    @Override
+    public TypeReference visitNullType(final TypeReference t, Void v) {
+        return t;
+    }
+
+    @Override
+    public TypeReference visitBottomType(final TypeReference t, Void v) {
+        return t;
+    }
+
+    @Override
+    public TypeReference visitRawType(final RawType t, Void v) {
+        return t;
+    }
+}

--- a/Procyon.CompilerTools/src/main/java/com/strobel/decompiler/languages/java/ast/AstMethodBodyBuilder.java
+++ b/Procyon.CompilerTools/src/main/java/com/strobel/decompiler/languages/java/ast/AstMethodBodyBuilder.java
@@ -840,7 +840,7 @@ public class AstMethodBodyBuilder {
                 return new ThrowStatement(arg1);
 
             case CheckCast:
-                return new CastExpression(operandType, arg1);
+                return arg1;
 
             case InstanceOf:
                 return new InstanceOfExpression( byteCode.getOffset(), arg1, operandType);
@@ -1315,12 +1315,13 @@ public class AstMethodBodyBuilder {
             final TypeReference aType = resolvedArgument.getType();
             final TypeReference pType = p.getParameterType();
 
-            if (isCastRequired(pType, aType, true)) {
-                arguments.set(
-                    i,
-                    new CastExpression(_astBuilder.convertType(pType, options), argument)
-                );
-            }
+            // TODO: completely broken... necessary for disambiguating methods but breaks generics completely
+//            if (isCastRequired(pType, aType, true)) {
+//                arguments.set(
+//                    i,
+//                    new CastExpression(_astBuilder.convertType(pType, options), argument)
+//                );
+//            }
         }
 
         int first = 0, last = parameterCount - 1;

--- a/Procyon.CompilerTools/src/main/java/com/strobel/decompiler/languages/java/ast/transforms/TransformationPipeline.java
+++ b/Procyon.CompilerTools/src/main/java/com/strobel/decompiler/languages/java/ast/transforms/TransformationPipeline.java
@@ -34,8 +34,6 @@ public final class TransformationPipeline {
             new EnumSwitchRewriterTransform(context),
             new EclipseEnumSwitchRewriterTransform(context),
             new AssertStatementTransform(context),
-            new RemoveImplicitBoxingTransform(context),
-            new RemoveRedundantCastsTransform(context),
             new ConvertLoopsTransform(context),
             new BreakTargetRelocation(context),
             new LabelCleanupTransform(context),
@@ -55,9 +53,10 @@ public final class TransformationPipeline {
             new FlattenSwitchBlocksTransform(context),
             new IntroduceInitializersTransform(context),
             new MarkReferencedSyntheticsTransform(context),
-            new RemoveRedundantCastsTransform(context), // (again due to inlined synthetic accessors)
-            new RewriteBoxingCastsTransform(context),
-            new InsertNecessaryConversionsTransform(context),
+//            new InsertNecessaryConversionsTransform(context),
+            new RemoveImplicitBoxingTransform(context),
+//            new RemoveRedundantCastsTransform(context),
+//            new RewriteBoxingCastsTransform(context),
             new IntroduceStringConcatenationTransform(context),
             new SimplifyAssignmentsTransform(context), // (again due to inlined synthetic accessors, string concatenation)
             new InlineEscapingAssignmentsTransform(context),

--- a/Procyon.CompilerTools/src/main/java/com/strobel/decompiler/languages/java/utilities/TypeUtilities.java
+++ b/Procyon.CompilerTools/src/main/java/com/strobel/decompiler/languages/java/utilities/TypeUtilities.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.strobel.core.CollectionUtilities.firstOfType;
 import static com.strobel.core.CollectionUtilities.firstOrDefault;
 import static com.strobel.core.CollectionUtilities.indexOf;
 
@@ -362,9 +363,13 @@ public final class TypeUtilities {
                     return null;
                 }
 
-                final MethodReference method = (MethodReference) callSite.getBootstrapArguments().get(0);
+                MethodReference method = firstOfType(callSite.getBootstrapArguments(), MethodReference.class);
+                if (method == null){
+                    MethodHandle methodHandle = firstOfType(callSite.getBootstrapArguments(), MethodHandle.class);
+                    method = methodHandle != null ? methodHandle.getMethod() : null;
+                }
 
-                return method.getDeclaringType();
+                return method != null? method.getDeclaringType() : null;
             }
             else {
                 final MethodDeclaration method = firstOrDefault(parent.getAncestors(MethodDeclaration.class));

--- a/Procyon.CompilerTools/src/test/java/com/strobel/decompiler/InfererTest.java
+++ b/Procyon.CompilerTools/src/test/java/com/strobel/decompiler/InfererTest.java
@@ -1,0 +1,170 @@
+package com.strobel.decompiler;
+
+import com.strobel.assembler.InputTypeLoader;
+import com.strobel.assembler.metadata.*;
+import com.strobel.decompiler.ast.typeinference.ConstraintSolver;
+import com.strobel.decompiler.ast.typeinference.EquivalenceSet;
+
+public class InfererTest {
+
+    static {
+        new MetadataSystem(new InputTypeLoader());
+    }
+
+    private static MetadataParser parser = new MetadataParser(MetadataSystem.instance());
+    private static TypeReference t = new GenericParameter("T");
+    private static TypeReference u = new GenericParameter("U");
+    private static TypeReference v = new GenericParameter("V");
+    private static TypeReference w = new GenericParameter("W");
+    private static TypeReference x = new GenericParameter("X");
+    private static TypeReference y = new GenericParameter("Y");
+    private static TypeDefinition string = parser.parseTypeDescriptor("java/lang/String").resolve();
+    private static TypeDefinition charSequence = parser.parseTypeDescriptor("java/lang/CharSequence").resolve();
+    private static TypeDefinition integer = parser.parseTypeDescriptor("java/lang/Integer").resolve();
+    private static TypeDefinition object = parser.parseTypeDescriptor("java/lang/Object").resolve();
+    private static TypeDefinition list = parser.parseTypeDescriptor("java/util/List").resolve();
+    private static TypeDefinition pair = parser.parseTypeDescriptor("com/strobel/core/Pair").resolve();
+
+    public static void main(String... args) {
+        testUndeterminedCycle();
+    }
+
+    private static void testSolveOrder() {
+        ConstraintSolver constraints = new ConstraintSolver();
+        constraints.addExtends(list.makeGenericType(t), u);
+        constraints.addExtends(u, v);
+        constraints.addExtends(v, w);
+        constraints.addExtends(w, list.makeGenericType(string));
+
+        for (EquivalenceSet s : constraints.solve()) {
+            System.out.println(s);
+        }
+
+        System.out.println();
+    }
+
+    private static void testSolveOrder2() { // Also tests partial solving
+        ConstraintSolver constraints = new ConstraintSolver();
+        constraints.addExtends(t, list.makeGenericType(u));
+        constraints.addExtends(t, list.makeGenericType(string));
+
+        for (EquivalenceSet s : constraints.solve()) {
+            System.out.println(s);
+        }
+
+        System.out.println();
+    }
+
+    private static void testSolveOrder3() {
+        ConstraintSolver constraints = new ConstraintSolver();
+        constraints.addExtends(u, charSequence);
+        constraints.addExtends(t, list.makeGenericType(string));
+        constraints.addExtends(t, list.makeGenericType(u));
+
+        for (EquivalenceSet s : constraints.solve()) {
+            System.out.println(s);
+        }
+
+        System.out.println();
+    }
+
+    private static void testUndeterminedCycle() {
+        ConstraintSolver constraints = new ConstraintSolver();
+
+        constraints.addExtends(v, w);
+        constraints.addExtends(u, v);
+        constraints.addExtends(w, t);
+        constraints.addExtends(t, u);
+
+        for (EquivalenceSet s : constraints.solve()) {
+            System.out.println(s);
+        }
+
+        System.out.println();
+    }
+
+    private static void testCasts() {
+        ConstraintSolver constraints = new ConstraintSolver();
+
+        constraints.addExtends(integer, t);
+        constraints.addExtends(t, integer);
+        constraints.addExtends(t, string);
+        constraints.addExtends(string, t);
+
+        for (EquivalenceSet s : constraints.solve()) {
+            System.out.println(s);
+        }
+
+        System.out.println();
+    }
+
+    private static void testCasts2() {
+        ConstraintSolver constraints = new ConstraintSolver();
+
+        // Integer <= T <= U <= String
+        // Possible outcomes:
+        //  1. T = Integer, U = Serializable
+        //  2. T = Serializable, U = String
+        // (depends on order)
+        constraints.addExtends(integer, t);
+        constraints.addExtends(t, u);
+        constraints.addExtends(u, string);
+
+        for (EquivalenceSet s : constraints.solve()) {
+            System.out.println(s);
+        }
+
+        System.out.println();
+    }
+
+    private static void testCasts3() {
+        ConstraintSolver constraints = new ConstraintSolver();
+
+        TypeReference listT = list.makeGenericType(t);
+        constraints.addExtends(listT, list.makeGenericType(string));
+        constraints.addExtends(listT, list.makeGenericType(integer));
+
+        for (EquivalenceSet s : constraints.solve()) {
+            System.out.println(s);
+        }
+
+        // Result is technically correct... Why wouldn't:
+        //
+        // List<Serializable> a = new ArrayList<>();
+        // List<Integer> b = (List<Integer>) a;
+        // List<String> c = (List<String>) a;
+        //
+        // be legal if replacing 'Serializable' with '?' is?
+
+        System.out.println();
+    }
+
+    private static void testPair() {
+        ConstraintSolver constraints = new ConstraintSolver();
+
+        TypeReference pairTU = pair.makeGenericType(t, u);
+        constraints.addExtends(pairTU, x);
+        constraints.addExtends(x, pair.makeGenericType(string, v));
+        constraints.addExtends(x, pair.makeGenericType(w, integer));
+
+        for (EquivalenceSet s : constraints.solve()) {
+            System.out.println(s);
+        }
+        System.out.println();
+    }
+
+    private static void testChain() {
+        ConstraintSolver constraints = new ConstraintSolver();
+
+        constraints.addExtends(w, string);
+        constraints.addExtends(t, u);
+        constraints.addExtends(u, v);
+        constraints.addExtends(string, t);
+        constraints.addExtends(v, w);
+
+        for (EquivalenceSet s : constraints.solve()) {
+            System.out.println(s);
+        }
+        System.out.println();
+    }
+}

--- a/Procyon.Core/src/main/java/com/strobel/core/CollectionUtilities.java
+++ b/Procyon.Core/src/main/java/com/strobel/core/CollectionUtilities.java
@@ -20,6 +20,7 @@ import com.strobel.util.EmptyArrayCache;
 
 import java.lang.reflect.Array;
 import java.util.*;
+import java.util.function.Function;
 
 /**
  * @author Mike Strobel
@@ -261,6 +262,15 @@ public final class CollectionUtilities {
         }
 
         throw Error.sequenceHasNoElements();
+    }
+
+    public static <T> T firstOfType(final Iterable<Object> collection, Class<T> type) {
+        for (Object o : VerifyArgument.notNull(collection, "collection")){
+            if (type.isInstance(o)){
+                return type.cast(o);
+            }
+        }
+        return null;
     }
 
     public static <T> T singleOrDefault(final Iterable<T> collection) {
@@ -694,6 +704,34 @@ public final class CollectionUtilities {
 
         return new Buffer<>(elementType, sequence.iterator()).toArray();
     }
+
+    public static <T, R> List<R> map(List<T> list, Function<T, R> function) {
+        List<R> result = new ArrayList<>(list.size());
+        for (T t : list) {
+            result.add(function.apply(t));
+        }
+        return result;
+    }
+
+    public static <T> String collectionToString(Collection<T> collection, Function<T, String> toString) {
+        return collectionToString(collection, toString, ", ");
+    }
+
+    public static <T> String collectionToString(Collection<T> collection, Function<T, String> toString, String separator) {
+        StringBuilder s = new StringBuilder();
+
+        boolean first = true;
+        for (T t : collection) {
+            if (!first) {
+                s.append(separator);
+            }
+            first = false;
+            s.append(toString.apply(t));
+        }
+
+        return s.toString();
+    }
+
 
     private final static class Buffer<E> {
         final Class<E> elementType;

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ allprojects {
     version procyonVersion
 
     group 'org.bitbucket.mstrobel'
-    sourceCompatibility = 1.7    // JDK version
+    sourceCompatibility = 1.8    // JDK version
 
     repositories {
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'idea'
 
-archivesBaseName = 'procyon'
+archivesBaseName = 'procyon-fabric'
 
 ext.getProcyonVersion = { ->
     final def fallbackVersion = "1.0-SNAPSHOT";
@@ -41,7 +41,7 @@ allprojects {
 
     version procyonVersion
 
-    group 'org.bitbucket.mstrobel'
+    group 'net.fabricmc'
     sourceCompatibility = 1.8    // JDK version
 
     repositories {
@@ -62,7 +62,7 @@ subprojects {
     apply plugin: 'maven'
 	apply plugin: 'maven-publish'
 
-    archivesBaseName = 'procyon-' + it.name.split("\\.")[1].toLowerCase()
+    archivesBaseName = 'procyon-fabric-' + it.name.split("\\.")[1].toLowerCase()
 
     jar {
         metaInf {


### PR DESCRIPTION
With the new system, there's almost perfect type inference except for some unchecked casts and some lambdas. Test it on Minecraft or DataFixerUpper (which is full of generics) to see the difference.

Here are some test cases that the new inference system can infer correctly but not the old one: https://gist.github.com/Runemoro/86852cdb80f8ffed54f066fe14522530