### PR TITLE
Fix enigma not recognizing method name in method references

### DIFF
--- a/Procyon.CompilerTools/src/main/java/com/strobel/decompiler/languages/java/JavaOutputVisitor.java
+++ b/Procyon.CompilerTools/src/main/java/com/strobel/decompiler/languages/java/JavaOutputVisitor.java
@@ -2270,7 +2270,7 @@ public final class JavaOutputVisitor implements IAstVisitor<Void, Void> {
             writeKeyword(node.getMethodName());
         }
         else {
-            writeIdentifier(node.getMethodName());
+            writeIdentifier(node.getMethodNameToken(), node.getMethodName());
         }
 
         endNode(node);


### PR DESCRIPTION
Signed-off-by: liach <liach@users.noreply.github.com>

After applying the patch in enigma manually:
![image](https://user-images.githubusercontent.com/7806504/65484785-896a0280-de65-11e9-923c-ba2bf8781cc1.png)
